### PR TITLE
Add  Multithreading to fix Cathode Heating performance issues

### DIFF
--- a/instrumentctl/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104.py
@@ -24,7 +24,8 @@ class PowerSupply9104:
                 if callback:
                     callback(result)
             except Exception as e:
-                self.log(f"Error in command worker: {str(e)}", LogLevel.ERROR)
+                # self.log(f"Error in command worker: {str(e)}", LogLevel.ERROR)
+                pass
             finally:
                 self.command_queue.task_done()
 
@@ -68,17 +69,17 @@ class PowerSupply9104:
                 raise ValueError("No response received from the device.")
             return response
         except serial.SerialException as e:
-            self.log(f"Serial error: {e}", LogLevel.ERROR)
+            # self.log(f"Serial error: {e}", LogLevel.ERROR)
             return None
         except ValueError as e:
-            self.log(f"Error processing response for command '{command}': {str(e)}", LogLevel.ERROR)
+            # self.log(f"Error processing response for command '{command}': {str(e)}", LogLevel.ERROR)
             return None
 
     def set_output(self, state):
         """Set the output on/off."""
         command = f"SOUT{state}"
         response = self.send_command(command)
-        self.log(f"Set output to {state}: {response}", LogLevel.DEBUG)
+        # self.log(f"Set output to {state}: {response}", LogLevel.DEBUG)
         return response
 
     def get_output_status(self):
@@ -92,13 +93,13 @@ class PowerSupply9104:
         command = f"VOLT {preset}{formatted_voltage:04d}"
     
         response = self.send_command(command)
-        self.log(f"Raw command sent to preset {preset}: {command}", LogLevel.DEBUG)
+        # self.log(f"Raw command sent to preset {preset}: {command}", LogLevel.DEBUG)
         if response and response.strip() == "OK":
-            self.log(f"Voltage set to {voltage:.2f}V for preset {preset}: {response}", LogLevel.INFO)
+            # self.log(f"Voltage set to {voltage:.2f}V for preset {preset}: {response}", LogLevel.INFO)
             return True
         else:
             error_message = "No response" if response is None else response
-            self.log(f"Error setting voltage: {error_message}", LogLevel.ERROR)
+            # self.log(f"Error setting voltage: {error_message}", LogLevel.ERROR)
             return False
     
     def set_current(self, preset, current):
@@ -107,11 +108,11 @@ class PowerSupply9104:
         command = f"CURR {preset}{formatted_current:04d}"
         response = self.send_command(command)
         if response and response.strip() == "OK":
-            self.log(f"Current set to {current:.2f}A for preset {preset}: {response}", LogLevel.INFO)
+            # self.log(f"Current set to {current:.2f}A for preset {preset}: {response}", LogLevel.INFO)
             return True
         else:
             error_message = "No response" if response is None else response
-            self.log(f"Error setting current: {error_message}", LogLevel.ERROR)
+            # self.log(f"Error setting current: {error_message}", LogLevel.ERROR)
             return False
 
     def ramp_voltage(self, target_voltage, ramp_rate=0.01, callback=None):
@@ -156,7 +157,7 @@ class PowerSupply9104:
         """Get the display readings for voltage and current mode."""
         self.flush_serial()
         command = "GETD"
-        self.log(f"Sent command:{command}", LogLevel.DEBUG)
+        # self.log(f"Sent command:{command}", LogLevel.DEBUG)
         return self.send_command(command)
     
     def parse_getd_response(self, response):
@@ -179,10 +180,10 @@ class PowerSupply9104:
             current = float(data[4:8]) / 100.0
             mode = "CV Mode" if data[8] == "0" else "CC Mode"
             
-            self.log(f"Parsed GETD response: {voltage:.2f}V, {current:.2f}A, {mode}", LogLevel.DEBUG)
+            # self.log(f"Parsed GETD response: {voltage:.2f}V, {current:.2f}A, {mode}", LogLevel.DEBUG)
             return voltage, current, mode
         except Exception as e:
-            self.log(f"Error parsing GETD response: {response}. {e}", LogLevel.ERROR)
+            # self.log(f"Error parsing GETD response: {response}. {e}", LogLevel.ERROR)
             return 0.0, 0.0, "Err"
     
     def get_voltage_current_mode(self):
@@ -195,14 +196,14 @@ class PowerSupply9104:
         for attempt in range(self.MAX_RETRIES):
             reading = self.get_display_readings()
             if reading:
-                self.log(f"Raw GETD response (attempt {attempt + 1}): {reading}", LogLevel.DEBUG)
+                # self.log(f"Raw GETD response (attempt {attempt + 1}): {reading}", LogLevel.DEBUG)
                 voltage, current, mode = self.parse_getd_response(reading)
                 if voltage is not None and current is not None:
                     return voltage, current, mode
-            self.log(f"Failed to get valid reading, attempt {attempt + 1}", LogLevel.WARNING)
+            # self.log(f"Failed to get valid reading, attempt {attempt + 1}", LogLevel.WARNING)
             time.sleep(0.1)
 
-        self.log(f"Failed to get valid reading, attempt {attempt + 1}", LogLevel.WARNING)
+        # self.log(f"Failed to get valid reading, attempt {attempt + 1}", LogLevel.WARNING)
         return None, None, "Err"
 
     def set_over_current_protection(self, ocp):
@@ -235,28 +236,28 @@ class PowerSupply9104:
     def get_preset_selection(self):
         """Get the current preset selection."""
         command = "GABC"
-        self.log(f"Raw command sent: {command}", LogLevel.DEBUG)
+        # self.log(f"Raw command sent: {command}", LogLevel.DEBUG)
         response = self.send_command(command)
-        self.log(f"Raw response received: {response}", LogLevel.DEBUG)
+        # self.log(f"Raw response received: {response}", LogLevel.DEBUG)
         if response:
-            self.log(f"Current preset selection: {response.strip()}", LogLevel.INFO)
+            # self.log(f"Current preset selection: {response.strip()}", LogLevel.INFO)
             return response.strip()
         else:
-            self.log("Failed to get preset selection", LogLevel.ERROR)
+            # self.log("Failed to get preset selection", LogLevel.ERROR)
             return None
 
     def set_preset_selection(self, preset):
         """Set the ABC select."""
         command = f"SABC{preset}"
-        self.log(f"Raw command sent: {command}", LogLevel.DEBUG)
+        # self.log(f"Raw command sent: {command}", LogLevel.DEBUG)
         response = self.send_command(command)
-        self.log(f"Raw response received: {response}", LogLevel.DEBUG)
+        # self.log(f"Raw response received: {response}", LogLevel.DEBUG)
         if response and response.strip() == "OK":
-            self.log(f"Successfully set preset selection to {preset}", LogLevel.INFO)
+            # self.log(f"Successfully set preset selection to {preset}", LogLevel.INFO)
             return True
         else:
             error_message = "No response" if response is None else response
-            self.log(f"Error setting preset selection: {error_message}", LogLevel.WARNING)
+            # self.log(f"Error setting preset selection: {error_message}", LogLevel.WARNING)
             return False
 
     def get_delta_time(self, index):
@@ -313,7 +314,7 @@ class PowerSupply9104:
         """Close the serial connection."""
         self.command_queue.join() # wait for all commands to complete
         self.ser.close()
-        self.log("Serial connection closed", LogLevel.INFO)
+        # self.log("Serial connection closed", LogLevel.INFO)
 
     def log(self, message, level=LogLevel.INFO):
         if self.logger:

--- a/instrumentctl/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104.py
@@ -2,7 +2,7 @@ import serial
 import threading
 import time
 from utils import LogLevel
-import queue
+import os
 
 class PowerSupply9104:
     MAX_RETRIES = 3 # 9104 display display reading attempts
@@ -11,96 +11,48 @@ class PowerSupply9104:
         self.ser = serial.Serial(port, baudrate, timeout=timeout)
         self.debug_mode = debug_mode
         self.logger = logger
-        self.command_queue = queue.Queue()
-        self.response_queue = queue.Queue()
-        self.last_readings = {'voltage': None, 'current:': None, 'mode': None}
-        self.lock = threading.Lock()
-        self.running = True
-        self.communication_thread = threading.Thread(target=self._communication_loop)
-        self.communication_thread.start()
-
-    def _communication_loop(self):
-        while self.running:
-            try:
-                command, event = self.command_queue.get(timeout=1)
-                response = self._execute_command(command)
-                self._process_response(command, response)
-                self.response_queue.put((command, response))
-                event.set()
-            except queue.Empty:
-                pass
-            except Exception as e:
-                self.log(f"Error in communication loop: {str(e)}", LogLevel.ERROR)
-
-    def _execute_command(self, command):
-        for _ in range(self.MAX_RETRIES):
-            try:
-                with self.lock:
-                    self.ser.write(f"{command}\r\n".encode())
-                    time.sleep(0.1)
-                    response = ""
-                    start_time = time.time()
-                    while True:
-                        line = self.ser.readline().decode().strip()
-                        if line:
-                            response += line + "\n"
-                            if "OK" in line or "ERROR" in line:
-                                break
-                        if time.time() - start_time > 1:
-                            break
-                    
-                    response = response.strip()
-                    if not response:
-                        raise ValueError("No response received from the device.")
-                    return response
-            except serial.SerialException as e:
-                self.log(f"Serial error: {e}", LogLevel.ERROR)
-            except ValueError as e:
-                self.log(f"Error processing response for command '{command}': {str(e)}", LogLevel.ERROR)
-        return None
         
-    def _process_response(self, command, response):
-        if command == "GETD" and response:
-            voltage, current, mode = self.parse_getd_response(response)
-            with self.lock:
-                self.last_readings = {'voltage': voltage, 'current': current, 'mode': mode}
-
     def is_connected(self):
         """Check if the serial connection is still active."""
         try:
-            with self.lock:
-                # Attempt to write a simple command to the device
-                self.ser.write(b'\r')  # Send a carriage return
-                # Try to read a response (there might not be one)
-                self.ser.read(1)
+            # Attempt to write a simple command to the device
+            self.ser.write(b'\r')  # Send a carriage return
+            # Try to read a response (there might not be one)
+            self.ser.read(1)
             return True
         except serial.SerialException:
             return False
 
     def flush_serial(self):
-        with self.lock:
-            self.ser.reset_input_buffer()    
+        self.ser.reset_input_buffer()    
 
-    def send_command(self, command, timeout=5):
-        event = threading.Event()
-        self.command_queue.put((command, event))
-
-        if not event.wait(timeout):
-            self.log(f"9104 Command '{command}' timed out after {timeout} seconds", LogLevel.ERROR)
-            return None
-        
+    def send_command(self, command):
+        """Send a command to the power supply and read the response."""
+        if self.debug_mode:
+            return "Mock response based on " + command
         try:
-            cmd, response = self.response_queue.get_nowait()
-            if cmd == command:
-                if response is None:
-                    self.log(f"Command '{command}' failed after {self.MAX_RETRIES} attempts", LogLevel.ERROR)
-                else:
-                    self.log(f"Received response for command '{command}': {response}", LogLevel.DEBUG)
-                return response
-            else:
-                self.log(f"Received response for wrong command. ")
-        except queue.Empty:
-            self.log(f"No response received for command '{command}'", LogLevel.ERROR)
+            self.ser.write(f"{command}\r".encode())
+            time.sleep(0.1) # allow small delay to let PS process command
+            response = ""
+            start_time = time.time()
+            while True:
+                line = self.ser.readline().decode().strip()
+                if line:
+                    response += line + "\n"
+                    if "OK" in line or "ERROR" in line:
+                        break
+                if time.time() - start_time > 1:
+                    break
+            
+            response = response.strip()
+            if not response:
+                raise ValueError("No response received from the device.")
+            return response
+        except serial.SerialException as e:
+            self.log(f"Serial error: {e}", LogLevel.ERROR)
+            return None
+        except ValueError as e:
+            self.log(f"Error processing response for command '{command}': {str(e)}", LogLevel.ERROR)
             return None
 
     def set_output(self, state):
@@ -116,7 +68,7 @@ class PowerSupply9104:
         return self.send_command(command)
 
     def set_voltage(self, preset, voltage):
-        """Set the output voltage. Assumes input voltage is in a form such as: 5.00 """
+        """Set the output voltage. Assumes input voltage is in a form such as: 5.00"""
         formatted_voltage = int(voltage * 100)
         command = f"VOLT {preset}{formatted_voltage:04d}"
     
@@ -340,8 +292,6 @@ class PowerSupply9104:
 
     def close(self):
         """Close the serial connection."""
-        self.running = False
-        self.communication_thread.join()
         self.ser.close()
         self.log("Serial connection closed", LogLevel.INFO)
 


### PR DESCRIPTION
During testing on 08/09, I observed performance issues that are likely caused by synchronous serial communication with the 9104 power supplies, which block the main thread and cause substantial lag in the application. When multiple power supplies are connected simultaneously, the delays in the responses sum together and make the application very unresponsive and nearly unusable. 

This PR will involve changes to implement asynchronous I/O operations allow the program to continue executing while waiting for I/O operations to complete. 

Changes at this time should be limited to the 9104PowerSupply class, and updates to CathodeHeatingSubsystem to accommodate the modified instrumentctl driver. 