### PR TITLE
fix multiple instances of Tk. use Toplevel. remove profiling

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,17 +3,13 @@ from tkinter import ttk
 import serial.tools.list_ports
 from dashboard import EBEAMSystemDashboard
 from utils import LogLevel
-import cProfile
-import pstats
 import sys
 
-def start_main_app(com_ports):
-    root = tk.Tk()
+def start_main_app(root, com_ports):
     app = EBEAMSystemDashboard(root, com_ports)
-    # app.messages_frame.set_log_level(LogLevel.DEBUG)
     root.mainloop()
 
-def config_com_ports():
+def config_com_ports(root):
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
         try:
             import pyi_splash
@@ -21,14 +17,14 @@ def config_com_ports():
         except ImportError:
             pass
 
-    config_root = tk.Tk()
+    config_root = tk.Toplevel(root)
     config_root.title("Configure COM Ports")
     config_root.geometry('600x400')
     
     com_ports = serial.tools.list_ports.comports()
     available_ports = [port.device for port in com_ports]
     
-    # Store port selections
+    # Store COM port selections
     selections = {}
 
     # Create a dropdown for each subsystem
@@ -42,7 +38,7 @@ def config_com_ports():
     def on_submit():
         selected_ports = {key: value.get() for key, value in selections.items()}
         config_root.destroy()
-        start_main_app(selected_ports)
+        start_main_app(root, selected_ports)
 
     submit_button = tk.Button(config_root, text="Submit", command=on_submit)
     submit_button.pack()
@@ -50,8 +46,5 @@ def config_com_ports():
     config_root.mainloop()
 
 if __name__ == "__main__":
-
-    profiler = cProfile.Profile()
-    profiler.enable()
-    config_com_ports()
-    profiler.disable()
+    root = tk.Tk()
+    config_com_ports(root)


### PR DESCRIPTION
`config_com_ports` uses `tk.Toplevel()` instead of `tk.Tk()`. one instance of `tk.Tk()` is created and passed around.

https://docs.python.org/3/library/tkinter.html#threading-model

![image](https://github.com/user-attachments/assets/81473b67-dfb9-4c85-b0f2-99d61360c464)
