### PR TITLE
Fix/vtrx com error flood

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, messagebox
 import serial.tools.list_ports
 from dashboard import EBEAMSystemDashboard
 from utils import LogLevel
@@ -37,14 +37,24 @@ def config_com_ports(root):
 
     def on_submit():
         selected_ports = {key: value.get() for key, value in selections.items()}
+        
+        # check that all COM ports are selected
+        if not all(selected_ports.values()):
+            messagebox.showerror("Error", "Please select all COM ports.")
+            return
+        
+        # show the root window
+        root.deiconify()
         config_root.destroy()
         start_main_app(root, selected_ports)
 
     submit_button = tk.Button(config_root, text="Submit", command=on_submit)
     submit_button.pack()
     
-    config_root.mainloop()
+    config_root.grab_set()
+    root.wait_window(config_root)
 
 if __name__ == "__main__":
     root = tk.Tk()
+    root.withdraw() # hide root window while configuring
     config_com_ports(root)

--- a/subsystem/vtrx.py
+++ b/subsystem/vtrx.py
@@ -90,7 +90,7 @@ class VTRXSubsystem:
         # If the new connection is successful, restart the serial thread
         if self.ser and self.ser.is_open:
             self.start_serial_thread()
-            self.log(f"Successfully updated VTRX COM port to {new_port}", LogLevel.INFO)
+            self.log(f"Updated VTRX COM port to {new_port}", LogLevel.INFO)
         else:
             self.log(f"Failed to establish connection on new port {new_port}", LogLevel.ERROR)
 
@@ -160,6 +160,7 @@ class VTRXSubsystem:
         data_parts = data.split(';')
         if len(data_parts) < 3:
             self.log("Incomplete data received.", LogLevel.WARNING)
+            self.log(f"Literal data from VTRX: {data}", LogLevel.VERBOSE)
             self.error_state = True
             self.update_gui_with_error_state()
             return


### PR DESCRIPTION
This PR aims to resolve a problem outlined in [this asana task](https://app.asana.com/0/1208196184307227/1208462567351008). 

When attempting to update the VTRX COM port at runtime, this recurring message dumps out in the logs:
```ERROR: Unexpected error: 'NoneType' object has no attribute 'readline'```

I believe this can be fixed with several changes:
- checking if the port is open before attempting to read data from it
- when updating the COM port, stop the existing serial reading trhead before starting a new one (preventing multiple threads from accessing `self.ser`)
- adding an error flag `self.error_logged` that is set to True and suppresses further identical error logs until the state changes (reset upon successful processing of data line) 
