### PR TITLE
increase vtrx plot Y limit

### DIFF
--- a/subsystem/vtrx.py
+++ b/subsystem/vtrx.py
@@ -242,7 +242,7 @@ class VTRXSubsystem:
             self.ax.set_xlabel('Time', fontsize=8)
             self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
             self.ax.set_yscale('log')
-            self.ax.set_ylim(1e-6, 1200.0)
+            self.ax.set_ylim(1e-6, 3000.0)
             self.ax.tick_params(axis='x', labelsize=6)
             self.ax.grid(True)
 


### PR DESCRIPTION
The 972b tends to report ambient pressure above 1.20E3 mbar which previously exceeded the pressure plot y limit.

This PR just increases the limit so that the reading is visible at ambient. 
