### PR TITLE
E5CN Connection Instability Fix

### DIFF
--- a/instrumentctl/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus.py
@@ -88,8 +88,8 @@ class E5CNModbus:
         """
         try:
             if self.client.is_socket_open():
-                self.log("Modbus client already connected.", LogLevel.DEBUG)
-                return True
+                self.client.close()
+                time.sleep(0.1) # for socket cleanup
 
             if self.client.connect():
                 self.log(f"E5CN Connected to port {self.client.comm_params.port}.", LogLevel.INFO)

--- a/instrumentctl/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus.py
@@ -88,8 +88,8 @@ class E5CNModbus:
         """
         try:
             if self.client.is_socket_open():
-                self.client.close()
-                time.sleep(0.1) # for socket cleanup
+                self.log("Modbus client already connected.", LogLevel.DEBUG)
+                return True
 
             if self.client.connect():
                 self.log(f"E5CN Connected to port {self.client.comm_params.port}.", LogLevel.INFO)

--- a/instrumentctl/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus.py
@@ -87,20 +87,21 @@ class E5CNModbus:
         Returns:
             bool: True if connected successfully, False otherwise.
         """
-        try:
-            if self.client.is_socket_open():
-                self.log("Modbus client already connected.", LogLevel.DEBUG)
-                return True
+        with self.client_lock:
+            try:
+                if self.client.is_socket_open():
+                    self.log("Modbus client already connected.", LogLevel.DEBUG)
+                    return True
 
-            if self.client.connect():
-                self.log(f"E5CN Connected to port {self.client.comm_params.port}.", LogLevel.INFO)
-                return True
-            else:
-                self.log("Failed to connect to the E5CN Modbus device.", LogLevel.ERROR)
+                if self.client.connect():
+                    self.log(f"E5CN Connected to port {self.client.comm_params.port}.", LogLevel.INFO)
+                    return True
+                else:
+                    self.log("Failed to connect to the E5CN Modbus device.", LogLevel.ERROR)
+                    return False
+            except Exception as e:
+                self.log(f"Error in connect: {str(e)}", LogLevel.ERROR)
                 return False
-        except Exception as e:
-            self.log(f"Error in connect: {str(e)}", LogLevel.ERROR)
-            return False
 
     def disconnect(self):
         self.client.close()

--- a/instrumentctl/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus.py
@@ -104,8 +104,9 @@ class E5CNModbus:
                 return False
 
     def disconnect(self):
-        self.client.close()
-        self.log("Disconnected from the E5CN Modbus device.", LogLevel.INFO)
+        with self.client_lock:
+            self.client.close()
+            self.log("Disconnected from the E5CN Modbus device.", LogLevel.INFO)
 
     def read_temperature(self, unit):
         """


### PR DESCRIPTION
On 11/14 Chase Ott noticed there were numerous errors in the log when testing the E5CN connection on `develop`. 

Here's the log capture: 
[log_2024-11-14_15-50-15.txt](https://github.com/user-attachments/files/17787091/log_2024-11-14_15-50-15.txt)

socket disconnections and reconnection attempting:
```
[15:49:37] - WARNING: Socket not open for unit 1. Attempting to reconnect...
[15:49:37] - WARNING: Socket not open for unit 2. Attempting to reconnect...
[15:49:37] - WARNING: Socket not open for unit 3. Attempting to reconnect...
```

incomplete modbus messages:
```
[15:49:37] - ERROR: Error reading temperature from unit 2: Modbus Error: [Input/Output] Modbus Error: [Invalid Message] Incomplete message received, expected at least 4 bytes (3 received)

frequently no response from slave controller:[15:49:38] - ERROR: Error reading temperature from unit 2: Modbus Error: [Input/Output] No Response received from the remote slave/Unable to decode response
