### PR TITLE
Bugfix/auto com config folder

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,12 +37,26 @@ def create_dummy_ports(subsystems):
     return {subsystem: f"DUMMY_COM{i+1}" for i, subsystem in enumerate(subsystems)}
 
 def start_main_app(com_ports):
+    """
+    Create and start the main EBEAM System Dashboard application.
+
+    :param com_ports: Dict mapping subsystems to their selected COM ports.
+    """
     root = tk.Tk()
     root.title("EBEAM System Dashboard")
     app = EBEAMSystemDashboard(root, com_ports)
     root.mainloop()
 
 def config_com_ports(saved_com_ports):
+    """
+    Display a configuration GUI for selecting COM ports for each subsystem.
+    Users can choose from available real COM ports or dummy ports.
+    If any subsystem is left blank, the user will be prompted to fill
+    in dummy ports or return to the config window.
+    
+    :param saved_com_ports: Dict of previously saved COM port settings.
+    """
+    # Close the PyInstaller splash if running as bundled executable
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
         try:
             import pyi_splash
@@ -70,9 +84,15 @@ def config_com_ports(saved_com_ports):
         frame = ttk.Frame(main_frame)
         frame.pack(pady=5, anchor='center')
 
-        label = tk.Label(frame, text=f"{subsystem} COM Port:", width=25, anchor='e')
+        label = tk.Label(
+            frame, 
+            text=f"{subsystem} COM Port:", 
+            width=25, 
+            anchor='e'
+        )
         label.pack(side=tk.LEFT, padx=(0, 10))
 
+        # Default to a previously saved port if available, otherwise blank
         selected_port = tk.StringVar(value=saved_com_ports.get(subsystem, ''))
 
         combobox = ttk.Combobox(
@@ -86,7 +106,11 @@ def config_com_ports(saved_com_ports):
         selections[subsystem] = selected_port
 
     def on_submit():
-        # Retrieve chosen ports for each subsystem
+        """
+        Handler for the 'Submit' button. Checks if all subsystems have a port
+        selected. If not, offers to fill those with dummy ports. If the user
+        refuses, they remain in the config window.
+        """
         selected_ports = {key: value.get() for key, value in selections.items()}
         
         # check that all COM ports are selected
@@ -106,10 +130,11 @@ def config_com_ports(saved_com_ports):
                 # if the user doesn't want to use dummy ports, they must pick real ones
                 return  # Stay on the configuration window
         
+        # save final selections
         save_com_ports(selected_ports)
         config_root.destroy()
         
-        # Start the main application
+        # Launch the main application
         start_main_app(selected_ports)
 
     submit_button = tk.Button(config_root, text="Submit", command=on_submit)
@@ -118,7 +143,7 @@ def config_com_ports(saved_com_ports):
     config_root.mainloop()
 
 if __name__ == "__main__":
-    
+    # Load previously saved COM ports, if any
     saved_com_ports = load_com_ports()
 
     # Prompt the user to confirm or change COM ports

--- a/main.py
+++ b/main.py
@@ -1,9 +1,21 @@
+import sys
 import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
+
 from dashboard import EBEAMSystemDashboard
-import sys
 from usr.com_port_config import save_com_ports, load_com_ports
+
+
+SUBSYSTEMS = [
+    'VTRXSubsystem', 
+    'CathodeA PS', 
+    'CathodeB PS', 
+    'CathodeC PS', 
+    'TempControllers', 
+    'Interlocks', 
+    'ProcessMonitors'
+]
 
 def create_dummy_port_labels(subsystems):
     """
@@ -37,21 +49,11 @@ def config_com_ports(saved_com_ports):
             pyi_splash.close()
         except ImportError:
             pass
-
-    subsystems = [
-        'VTRXSubsystem', 
-        'CathodeA PS', 
-        'CathodeB PS', 
-        'CathodeC PS', 
-        'TempControllers', 
-        'Interlocks', 
-        'ProcessMonitors'
-    ]
     
     # Get real COM ports on the system
     real_ports = [port.device for port in serial.tools.list_ports.comports()]
     # Create a combined list of real + dummy port labels for user to pick
-    dummy_port_labels = create_dummy_port_labels(subsystems)
+    dummy_port_labels = create_dummy_port_labels(SUBSYSTEMS)
     # Combine real + dummy port labels
     combined_port_options = real_ports + dummy_port_labels
 
@@ -64,7 +66,7 @@ def config_com_ports(saved_com_ports):
     main_frame.pack(side=tk.TOP, fill=tk.X)
 
     # Create a dropdown for each subsystem
-    for subsystem in subsystems:
+    for subsystem in SUBSYSTEMS:
         frame = ttk.Frame(main_frame)
         frame.pack(pady=5, anchor='center')
 

--- a/usr/com_port_config.py
+++ b/usr/com_port_config.py
@@ -6,6 +6,8 @@ CONFIG_FILE = 'usr/usr_data/com_ports.json'
 
 def save_com_ports(com_ports, filepath=CONFIG_FILE):
     """Save COM port selections to a JSON file."""
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
     try:
         with open(filepath, 'w') as file:
             json.dump(com_ports, file, indent=4)


### PR DESCRIPTION
This PR resolves a missing-file issue relating to auto saving/loading COM port configuration files in the usr/usr_data dir.

Additionally, it modifies the main configuration workflow. 
`main.py` now offers both real COM ports and dummy ports in the same selection dropdown by default, which allows the user to mix and match as needed for testing, regardless of how many real ports are enumerated on the system. 