### PR TITLE
Log frame tweaks and fixes

### DIFF
--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -242,7 +242,7 @@ class VTRXSubsystem:
             self.ax.set_xlabel('Time', fontsize=8)
             self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
             self.ax.set_yscale('log')
-            self.ax.set_ylim(1e-6, 3000.0)
+            self.ax.set_ylim(1e-7, 3000.0)
             self.ax.tick_params(axis='x', labelsize=6)
             self.ax.grid(True)
 

--- a/utils.py
+++ b/utils.py
@@ -122,7 +122,7 @@ class MessagesFrame:
         self.logging_indicator_canvas = tk.Canvas(self.frame, width=16, height=16, highlightthickness=0)
         self.logging_indicator_canvas.grid(row=2, column=3, padx=(0, 10), pady=10)
         self.logging_indicator_circle = self.logging_indicator_canvas.create_oval(
-            2, 2, 14, 14, fill="green", outline="black", width=2
+            2, 2, 14, 14, fill="#00FF24", outline="black", width=2
         )
 
         self.file_logging_enabled = True

--- a/utils.py
+++ b/utils.py
@@ -146,10 +146,13 @@ class MessagesFrame:
             self.file_logging_enabled = False
             self.logger.log_to_file = False
             if self.logger.log_file:
-                self.logger.log_file.close()
+                try:
+                    self.logger.log_file.close()
+                except Exception as e:
+                    print(f"Error closing log file: {e}")
+                self.logger.log_file = None
             self.toggle_file_logging_button.config(text="Record Log: OFF")
             self.logging_indicator_canvas.itemconfig(self.logging_indicator_circle, fill="gray")
-            self.logger.info("Log recording has been turned OFF.")
         else:
             # Currently OFF, turn it ON
             self.file_logging_enabled = True
@@ -157,7 +160,10 @@ class MessagesFrame:
             if not self.logger.log_file:  # if no file is open, set up a new one
                 self.logger.setup_log_file()
             self.toggle_file_logging_button.config(text="Record Log: ON")
-            self.logging_indicator_canvas.itemconfig(self.logging_indicator_circle, fill="green")
+            self.logging_indicator_canvas.itemconfig(
+                self.logging_indicator_circle, 
+                fill="#00FF24"
+            )
             self.logger.info("Log recording has been turned ON.")
 
     def set_log_level(self, level):

--- a/utils.py
+++ b/utils.py
@@ -140,9 +140,9 @@ class MessagesFrame:
         self.trim_text()
 
     def toggle_file_logging(self):
-        # Toggle the file_logging_enabled state
         if self.file_logging_enabled:
             # Currently ON, turn it OFF
+            self.logger.info("Log recording has been turned OFF.")
             self.file_logging_enabled = False
             self.logger.log_to_file = False
             if self.logger.log_file:
@@ -151,12 +151,14 @@ class MessagesFrame:
                 except Exception as e:
                     print(f"Error closing log file: {e}")
                 self.logger.log_file = None
+
             self.toggle_file_logging_button.config(text="Record Log: OFF")
             self.logging_indicator_canvas.itemconfig(self.logging_indicator_circle, fill="gray")
         else:
             # Currently OFF, turn it ON
             self.file_logging_enabled = True
             self.logger.log_to_file = True
+            
             if not self.logger.log_file:  # if no file is open, set up a new one
                 self.logger.setup_log_file()
             self.toggle_file_logging_button.config(text="Record Log: ON")


### PR DESCRIPTION
Misc. logging-related issues discovered on 1/3:

- Indicator light color is inconsistent with other "active" green colors in app
- Repeated "Error writing to log file: I/O operation on closed file" error was observed after disabling continuous logging
    - I was able to recreate this, but only after disabling, then re-enabling did it appear