### PR TITLE
VTRX circle indicator alignment

### DIFF
--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -207,6 +207,9 @@ class VTRXSubsystem:
         except ValueError as e:    
             self.log(f"VTRX Data processing error: {e}", LogLevel.ERROR)
             self.error_state = True
+        except IndexError as e:
+            self.log(f"VTRX Data processing error: Insufficient segments - {data}. Error: {e}", LogLevel.ERROR)
+            self.error_state = True
 
     def log(self, message, level=LogLevel.INFO):
         if self.logger:

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -199,72 +199,73 @@ class VTRXSubsystem:
             print(f"{level.name}: {message}")
 
     def setup_gui(self):
-            layout_frame = tk.Frame(self.parent)
-            layout_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        
+        layout_frame = tk.Frame(self.parent)
+        layout_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
-            # Formatting status indicators
-            switches_frame = tk.Frame(layout_frame, width=135)
-            switches_frame.pack(side=tk.LEFT, fill=tk.Y, padx=5) 
+        # Formatting status indicators
+        switches_frame = tk.Frame(layout_frame, width=135)
+        switches_frame.pack(side=tk.LEFT, fill=tk.Y, padx=5) 
 
-            # Setup labels for each switch
-            switch_labels = [
-                "Pumps Power ON", 
-                "Turbo Rotor ON", 
-                "Turbo Vent OPEN",
-                "972b Power ON", 
-                "Turbo Gate CLOSED",
-                "Turbo Gate OPEN", 
-                "Argon Gate OPEN", 
-                "Argon Gate CLOSED"
-            ]
-            label_width = 17
+        # Setup labels for each switch
+        switch_labels = [
+            "Pumps Power ON", 
+            "Turbo Rotor ON", 
+            "Turbo Vent OPEN",
+            "972b Power ON", 
+            "Turbo Gate CLOSED",
+            "Turbo Gate OPEN", 
+            "Argon Gate OPEN", 
+            "Argon Gate CLOSED"
+        ]
+        label_width = 17
 
-            switches_frame.grid_columnconfigure(0, weight=1)
-            switches_frame.grid_columnconfigure(1, weight=0)
+        switches_frame.grid_columnconfigure(0, weight=1)
+        switches_frame.grid_columnconfigure(1, weight=0)
 
-            for idx, switch in enumerate(switch_labels):
-                tk.Label(switches_frame, text=switch, anchor='e', width=label_width).grid(
-                    row=idx, column=0, pady=2, sticky='e'
-                )
-                canvas, oval_id = self._create_indicator_circle(switches_frame, color='grey')
-                canvas.grid(row=idx, column=1, pady=2, padx=(5,0), sticky='w')
-                self.circle_indicators.append((canvas, oval_id))
+        for idx, switch in enumerate(switch_labels):
+            tk.Label(switches_frame, text=switch, anchor='e', width=label_width).grid(
+                row=idx, column=0, pady=2, sticky='e'
+            )
+            canvas, oval_id = self._create_indicator_circle(switches_frame, color='grey')
+            canvas.grid(row=idx, column=1, pady=2, padx=(5,0), sticky='w')
+            self.circle_indicators.append((canvas, oval_id))
 
-            # Pressure label setup
-            self.label_pressure = tk.Label(switches_frame, text="No data...", anchor='e', width=label_width,
-                                        font=('Helvetica', 11, 'bold'))
-            self.label_pressure.grid(row=len(switch_labels), column=0, columnspan=2, pady=1, sticky='e')
+        # Pressure label setup
+        self.label_pressure = tk.Label(switches_frame, text="No data...", anchor='e', width=label_width,
+                                    font=('Helvetica', 11, 'bold'))
+        self.label_pressure.grid(row=len(switch_labels), column=0, columnspan=2, pady=1, sticky='e')
 
-            # Buttons
-            button_frame = tk.Frame(switches_frame)
-            button_frame.grid(row=len(switch_labels)+1, column=0, columnspan=2, pady=1)
-            
-            self.reset_button = tk.Button(button_frame, text="Reset VTRX", command=self.confirm_reset)
-            self.reset_button.pack(side=tk.LEFT, padx=5)
-            
-            self.clear_button = tk.Button(button_frame, text="Clear Plot", command=self.clear_graph)
-            self.clear_button.pack(side=tk.LEFT, padx=5)
+        # Buttons
+        button_frame = tk.Frame(switches_frame)
+        button_frame.grid(row=len(switch_labels)+1, column=0, columnspan=2, pady=1)
+        
+        self.reset_button = tk.Button(button_frame, text="Reset VTRX", command=self.confirm_reset)
+        self.reset_button.pack(side=tk.LEFT, padx=5)
+        
+        self.clear_button = tk.Button(button_frame, text="Clear Plot", command=self.clear_graph)
+        self.clear_button.pack(side=tk.LEFT, padx=5)
 
-            # Plot frame
-            plot_frame = tk.Frame(layout_frame)
-            plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=1) 
-            self.fig, self.ax = plt.subplots()
-            self.fig.subplots_adjust(left=0.15, right=0.99, top=0.99, bottom=0.1) 
-            self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
-            self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
-            self.fig.autofmt_xdate()  
-            self.ax.set_title('')
-            self.ax.set_xlabel('Time', fontsize=8)
-            self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
-            self.ax.set_yscale('log')
-            self.ax.set_ylim(1e-7, 3000.0)
-            self.ax.tick_params(axis='x', labelsize=6)
-            self.ax.grid(True)
+        # Plot frame
+        plot_frame = tk.Frame(layout_frame)
+        plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=1) 
+        self.fig, self.ax = plt.subplots()
+        self.fig.subplots_adjust(left=0.15, right=0.99, top=0.99, bottom=0.1) 
+        self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
+        self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
+        self.fig.autofmt_xdate()  
+        self.ax.set_title('')
+        self.ax.set_xlabel('Time', fontsize=8)
+        self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
+        self.ax.set_yscale('log')
+        self.ax.set_ylim(1e-7, 3000.0)
+        self.ax.tick_params(axis='x', labelsize=6)
+        self.ax.grid(True)
 
-            self.canvas = FigureCanvasTkAgg(self.fig, master=plot_frame)
-            self.canvas.draw()
-            self.canvas_widget = self.canvas.get_tk_widget()
-            self.canvas_widget.pack(fill=tk.BOTH, expand=True)
+        self.canvas = FigureCanvasTkAgg(self.fig, master=plot_frame)
+        self.canvas.draw()
+        self.canvas_widget = self.canvas.get_tk_widget()
+        self.canvas_widget.pack(fill=tk.BOTH, expand=True)
     
     def update_gui(self, pressure_value, pressure_raw, switch_states):
         if self.error_state:

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -151,6 +151,11 @@ class VTRXSubsystem:
             self.parent.after(500, self.process_queue)
 
     def update_gui_with_error_state(self):
+        """Update GUI elements to reflect error state.
+        
+        Sets indicators to red, updates pressure label, and changes plot appearance
+        to indicate error condition.
+        """
         self.label_pressure.config(text="No data...", fg="red")
         self.line.set_color('red')
         self.ax.set_title('(Error)', fontsize=10, color='red')
@@ -159,6 +164,17 @@ class VTRXSubsystem:
         self.canvas.draw_idle()
 
     def handle_serial_data(self, data):
+        """Process raw serial data from VTRX system.
+    
+        Args:
+            data (str): Semicolon-separated string containing:
+                - pressure value (float)
+                - raw pressure string
+                - binary switch states
+                - optional error messages
+                
+        Format: "pressure;raw_pressure;switch_states[;errors...]"
+        """
         data_parts = data.split(';')
         if len(data_parts) < 3:
             self.log("Incomplete data received.", LogLevel.WARNING)
@@ -199,7 +215,13 @@ class VTRXSubsystem:
             print(f"{level.name}: {message}")
 
     def setup_gui(self):
+        """Initialize and configure the GUI components including status indicators and plot.
         
+        Creates:
+        - Status indicator frame with switch state indicators
+        - Pressure label and control buttons
+        - Real-time pressure plot with logarithmic scale
+        """
         layout_frame = tk.Frame(self.parent)
         layout_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
@@ -268,6 +290,13 @@ class VTRXSubsystem:
         self.canvas_widget.pack(fill=tk.BOTH, expand=True)
     
     def update_gui(self, pressure_value, pressure_raw, switch_states):
+        """Update GUI with new pressure and switch state data.
+    
+        Args:
+            pressure_value (float): Current pressure reading
+            pressure_raw (str): Raw pressure string from sensor
+            switch_states (list): List of binary switch states
+        """
         if self.error_state:
             return
         
@@ -290,7 +319,7 @@ class VTRXSubsystem:
 
             for idx, state in enumerate(switch_states):
                 canvas, oval_id = self.circle_indicators[idx]
-                canvas.itemconfig(oval_id, fill='#00FF24' if state == 1 else 'red')
+                canvas.itemconfig(oval_id, fill='#00FF24' if state == 1 else 'grey')
             
             self.log(f"GUI updated with pressure: {pressure_raw} mbar", LogLevel.DEBUG)
 

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -222,7 +222,6 @@ class VTRXSubsystem:
             switches_frame.grid_columnconfigure(0, weight=1)
             switches_frame.grid_columnconfigure(1, weight=0)
 
-
             for idx, switch in enumerate(switch_labels):
                 tk.Label(switches_frame, text=switch, anchor='e', width=label_width).grid(
                     row=idx, column=0, pady=2, sticky='e'
@@ -252,6 +251,8 @@ class VTRXSubsystem:
             self.fig, self.ax = plt.subplots()
             self.fig.subplots_adjust(left=0.15, right=0.99, top=0.99, bottom=0.1) 
             self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
+            self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
+            self.fig.autofmt_xdate()  
             self.ax.set_title('')
             self.ax.set_xlabel('Time', fontsize=8)
             self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
@@ -296,13 +297,17 @@ class VTRXSubsystem:
         # Update the data for the line, rather than recreating it
         self.line.set_data(self.x_data, self.y_data)
         self.ax.relim()  # Recalculate limits based on the new data
-        self.ax.autoscale_view(True, True, True)
+        self.ax.autoscale_view(True, True, False)
+
+        current_time = self.x_data[-1]
+        start_time = current_time - datetime.timedelta(seconds=self.time_window)
+        self.ax.set_xlim(start_time, current_time)
 
         # Efficiently update the canvas without redrawing everything
         self.canvas.draw_idle()  # Use draw_idle instead of draw
 
         # Adjust the x-axis to show the latest data
-        self.ax.set_xlim(left=max(self.x_data[0], self.x_data[-1] - datetime.timedelta(seconds=self.time_window)), right=self.x_data[-1])
+        # self.ax.set_xlim(left=max(self.x_data[0], self.x_data[-1] - datetime.timedelta(seconds=self.time_window)), right=self.x_data[-1])
 
         self.canvas.flush_events()
 

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -53,7 +53,7 @@ class VTRXSubsystem:
         self.data_queue = queue.Queue()
         self.x_data = []
         self.y_data = []
-        self.indicators = {
+        self.indicators = { # TODO: replace this with Tkinter Canvas widget
             0: tk.PhotoImage(file=resource_path("media/off.png")),
             1: tk.PhotoImage(file=resource_path("media/on.png"))
         }


### PR DESCRIPTION
The circle indicators in subsystem/vtrx/vtrx.py are unique from other subsystems and should be refactored to be consistent with the rest of the app.

Currently, we're storing two images (`off.png` and `on.png`) and swap them in and out with a call to `label.config(image=..)` to change the state. This works for now, but:
- adds unnecessary file dependencies and fixed paths to `media/`
- isn't flexible for resizing
-  does not match the approach of making circular indicators in interlocks.py or utils.py.

<br>

This PR should cover:
- removing the original PhotoImage approach
- deleting the .png files from media/ and propagating this deletion to the remote
- create a helper function in vtrx.py to generate a circle indicator using [Tkinter Canvas](https://www.geeksforgeeks.org/python-tkinter-create-different-shapes-using-canvas-class/#)
   - Review [this method](https://github.com/uw-loci/EBEAM_dashboard/blob/fc051fb6d70d4bef3240e2366f95e70489203698/subsystem/interlocks/interlocks.py#L148-L159) in InterlocksSubsystem for reference
   - Another [example](https://github.com/uw-loci/EBEAM_dashboard/blob/fc051fb6d70d4bef3240e2366f95e70489203698/utils.py#L124-L126) in utils.py 
- Replace old label update calls with updated fill colors
    - use `#00FF24` for active/asserted