### PR TITLE
Feature/graceful exit

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -55,6 +55,7 @@ class EBEAMSystemDashboard:
     def __init__(self, root, com_ports):
         self.root = root
         self.com_ports = com_ports
+        self.stop_threads = False
         self.root.title("EBEAM Control System Dashboard")
         
         # if save file exists call it and open it
@@ -75,6 +76,15 @@ class EBEAMSystemDashboard:
 
         # Set up different subsystems within their respective frames
         self.create_subsystems()
+
+    def cleanup(self):
+        """Clean up the dashboard before closing the application."""
+        self.stop_threads = True
+        self.root.quit()
+        for subsystem in self.subsystems.values():
+            if hasattr(subsystem, 'close'):
+                subsystem.close()
+        print("Cleaned up resources.")
 
     def setup_main_pane(self):
         """Initialize the main layout pane and its rows for subsystem organization."""

--- a/dashboard.py
+++ b/dashboard.py
@@ -55,7 +55,6 @@ class EBEAMSystemDashboard:
     def __init__(self, root, com_ports):
         self.root = root
         self.com_ports = com_ports
-        self.stop_threads = False
         self.root.title("EBEAM Control System Dashboard")
         
         # if save file exists call it and open it
@@ -78,13 +77,13 @@ class EBEAMSystemDashboard:
         self.create_subsystems()
 
     def cleanup(self):
-        """Clean up the dashboard before closing the application."""
-        self.stop_threads = True
-        self.root.quit()
+        """Closes all open com ports before quitting the application."""
+
+        print("Cleaning up com ports...")
         for subsystem in self.subsystems.values():
-            if hasattr(subsystem, 'close'):
-                subsystem.close()
-        print("Cleaned up resources.")
+            if hasattr(subsystem, 'close_com_ports'):
+                subsystem.close_com_ports()
+        print("Cleaned up com ports.")
 
     def setup_main_pane(self):
         """Initialize the main layout pane and its rows for subsystem organization."""

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -358,17 +358,17 @@ class DP16ProcessMonitor:
 
     def disconnect(self):
         # Stop polling thread
-        self._is_running = False
-        if self._thread and self._thread.is_alive():
-            self._thread.join()
+        # self._is_running = False
+        # if self._thread and self._thread.is_alive():
+        #     self._thread.join()
         
         # Close connection
-        with self.modbus_lock:
-            if self.client.is_socket_open():
-                self.client.close()
-                self.log("Disconnected from DP16 Process Monitors", LogLevel.INFO)
-            else:
-                self.log("No active connection to DP16 Process Monitors", LogLevel.DEBUG)
+        # with self.modbus_lock:
+        if self.client.is_socket_open():
+            self.client.close()
+            self.log("Disconnected from DP16 Process Monitors", LogLevel.INFO)
+        else:
+            self.log("No active connection to DP16 Process Monitors", LogLevel.INFO)
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -367,6 +367,8 @@ class DP16ProcessMonitor:
             if self.client.is_socket_open():
                 self.client.close()
                 self.log("Disconnected from DP16 Process Monitors", LogLevel.INFO)
+            else:
+                self.log("No active connection to DP16 Process Monitors", LogLevel.DEBUG)
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -138,7 +138,7 @@ class E5CNModbus:
 
     def disconnect(self):
         """Disconnect from the Modbus device with proper locking."""
-        with self.connection_lock:
+        with self.modbus_lock:
             try:
                 if self.client.is_socket_open():
                     self.client.close()

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -138,13 +138,15 @@ class E5CNModbus:
 
     def disconnect(self):
         """Disconnect from the Modbus device with proper locking."""
-        with self.modbus_lock:
-            try:
-                if self.client.is_socket_open():
-                    self.client.close()
-                    self.log("Disconnected from the E5CN Modbus device.", LogLevel.INFO)
-            except Exception as e:
-                self.log(f"Error in disconnect: {str(e)}", LogLevel.ERROR)
+       # with self.modbus_lock:
+        try:
+            if self.client.is_socket_open():
+                self.client.close()
+                self.log("Disconnected from the E5CN Modbus device.", LogLevel.INFO)
+            else:
+                self.log("Client already disconnected from E5CN Modbus device", LogLevel.INFO)
+        except Exception as e:
+            self.log(f"Error in disconnect: {str(e)}", LogLevel.ERROR)
 
     def read_temperature(self, unit):
         attempts = 3

--- a/instrumentctl/G9SP_interlock/g9_driver.py
+++ b/instrumentctl/G9SP_interlock/g9_driver.py
@@ -120,7 +120,7 @@ class G9Driver:
             except Exception as e:
                 self.log(f"Communication thread error: {str(e)}", LogLevel.ERROR)
                 #TODO: this might be solved with the comport detection, but if not might what to define this somewhere else
-                self._response_queue.queue[0] = ([0] * 13, [0] * 13, 0)
+                #self._response_queue.queue[0] = ([0] * 13, [0] * 13, 0)
                 time.sleep(0.5) # back off on errors
                 
             time.sleep(0.1)  # minimum sleep between successful reads

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -428,8 +428,9 @@ class PowerSupply9104:
 
     def close(self):
         """Close the serial connection."""
-        self.ser.close()
-        self.log("Serial connection closed", LogLevel.INFO)
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+            self.log(f"Closed serial port {self.port}", LogLevel.INFO)
 
     def log(self, message, level=LogLevel.INFO):
         if self.logger:

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -431,6 +431,8 @@ class PowerSupply9104:
         if self.ser and self.ser.is_open:
             self.ser.close()
             self.log(f"Closed serial port {self.port}", LogLevel.INFO)
+        else: 
+            self.log(f"{self.port} port already closed", LogLevel.INFO)
 
     def log(self, message, level=LogLevel.INFO):
         if self.logger:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import sys
 import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
+import signal
 
 from dashboard import EBEAMSystemDashboard
 from usr.com_port_config import save_com_ports, load_com_ports
@@ -54,6 +55,12 @@ def start_main_app(com_ports):
             app.cleanup()
             root.destroy()
         return "break"
+    
+    def handle_termination(signum, frame):
+        """Handle forced termination (End Task, kill command, etc.)"""
+        print("Forced termination detected. Cleaning up...")
+        app.cleanup()
+        root.destroy()
     
     def toggle_fullscreen(event=None):
         nonlocal fullscreen
@@ -168,9 +175,12 @@ def start_main_app(com_ports):
     root.bind('<Escape>', escape_handler)       # Exit fullscreen
     root.bind('<Control-m>', toggle_maximize)   # Toggle maximize  
     root.bind('<Control-s>', save_logs)         # Save log file
-    
-    # Binding the close button to quit_app
-    root.protocol("WM_DELETE_WINDOW", quit_app)
+
+    # Bind close button (X) to quit_app
+    root.protocol("WM_DELETE_WINDOW", quit_app)  
+
+    # Handle SIGTERM (Task Manager, kill command)
+    signal.signal(signal.SIGTERM, handle_termination)
 
     app = EBEAMSystemDashboard(root, com_ports)
     root.mainloop()

--- a/main.py
+++ b/main.py
@@ -51,13 +51,7 @@ def start_main_app(com_ports):
     
     def quit_app(event=None):
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
-            # Signal all threads to stop
-            # if hasattr(app, 'subsystems'):
-            #     for subsystem in app.subsystems.values():
-            #         if hasattr(subsystem, 'stop'):
-            #             subsystem.stop()
-            
-                # Destroy the root window
+            app.cleanup()
             root.destroy()
         return "break"
     
@@ -176,12 +170,7 @@ def start_main_app(com_ports):
     root.bind('<Control-s>', save_logs)         # Save log file
 
     app = EBEAMSystemDashboard(root, com_ports)
-    try:
-        root.mainloop()
-    except KeyboardInterrupt:
-        print("Application interrupted. Exiting...")
-        app.cleanup()
-        root.destroy()
+    root.mainloop()
 
 def config_com_ports(saved_com_ports):
     """

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ import sys
 import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
-import signal
 
 from dashboard import EBEAMSystemDashboard
 from usr.com_port_config import save_com_ports, load_com_ports
@@ -55,12 +54,6 @@ def start_main_app(com_ports):
             app.cleanup()
             root.destroy()
         return "break"
-    
-    def handle_termination(signum, frame):
-        """Handle forced termination (End Task, kill command, etc.)"""
-        print("Forced termination detected. Cleaning up...")
-        app.cleanup()
-        root.destroy()
     
     def toggle_fullscreen(event=None):
         nonlocal fullscreen
@@ -178,9 +171,6 @@ def start_main_app(com_ports):
 
     # Bind close button (X) to quit_app
     root.protocol("WM_DELETE_WINDOW", quit_app)  
-
-    # Handle SIGTERM (Task Manager, kill command)
-    signal.signal(signal.SIGTERM, handle_termination)
 
     app = EBEAMSystemDashboard(root, com_ports)
     root.mainloop()

--- a/main.py
+++ b/main.py
@@ -168,9 +168,7 @@ def start_main_app(com_ports):
     root.bind('<Escape>', escape_handler)       # Exit fullscreen
     root.bind('<Control-m>', toggle_maximize)   # Toggle maximize  
     root.bind('<Control-s>', save_logs)         # Save log file
-
-    # Bind close button (X) to quit_app
-    root.protocol("WM_DELETE_WINDOW", quit_app)  
+  
 
     app = EBEAMSystemDashboard(root, com_ports)
     root.mainloop()

--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ def start_main_app(com_ports):
 
     # Track fullscreen state
     fullscreen = False
-    
+  
     def quit_app(event=None):
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
             app.cleanup()
@@ -168,6 +168,9 @@ def start_main_app(com_ports):
     root.bind('<Escape>', escape_handler)       # Exit fullscreen
     root.bind('<Control-m>', toggle_maximize)   # Toggle maximize  
     root.bind('<Control-s>', save_logs)         # Save log file
+    
+    # Binding the close button to quit_app
+    root.protocol("WM_DELETE_WINDOW", quit_app)
 
     app = EBEAMSystemDashboard(root, com_ports)
     root.mainloop()

--- a/main.py
+++ b/main.py
@@ -51,6 +51,13 @@ def start_main_app(com_ports):
     
     def quit_app(event=None):
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
+            # Signal all threads to stop
+            # if hasattr(app, 'subsystems'):
+            #     for subsystem in app.subsystems.values():
+            #         if hasattr(subsystem, 'stop'):
+            #             subsystem.stop()
+            
+                # Destroy the root window
             root.destroy()
         return "break"
     
@@ -169,7 +176,12 @@ def start_main_app(com_ports):
     root.bind('<Control-s>', save_logs)         # Save log file
 
     app = EBEAMSystemDashboard(root, com_ports)
-    root.mainloop()
+    try:
+        root.mainloop()
+    except KeyboardInterrupt:
+        print("Application interrupted. Exiting...")
+        app.cleanup()
+        root.destroy()
 
 def config_com_ports(saved_com_ports):
     """

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1233,7 +1233,7 @@ class CathodeHeatingSubsystem:
 
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
-                self.temperature_controller.stop_reading()
+               # self.temperature_controller.stop_reading()
                 self.temperature_controller.disconnect()
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1234,5 +1234,6 @@ class CathodeHeatingSubsystem:
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
                 self.temperature_controller.stop_reading()
+                self.temperature_controller.disconnect()
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1221,3 +1221,18 @@ class CathodeHeatingSubsystem:
         except Exception as e:
             self.log(f"Error reading temperature from Unit {unit}: {str(e)}", LogLevel.ERROR)
             msgbox.showerror("Temperature Read Error", f"Error reading temperature from Unit {unit}: {str(e)}")
+    
+    def close_com_ports(self):
+        """
+        Closes the serial port connection and stops the serial thread upon quitting the application.
+        """
+        if hasattr(self, 'power_supplies') and self.power_supplies:
+            for ps in self.power_supplies:
+                if hasattr(ps, 'close'):
+                    ps.close()
+
+        if hasattr(self, 'temperature_controller') and self.temperature_controller:
+            try:
+                self.temperature_controller.stop_reading()
+            except Exception as e:
+                self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -41,6 +41,7 @@ class InterlocksSubsystem:
         self.parent = parent
         self.logger = logger
         self.frames = frames
+        self.com_port = com_ports
         self.last_error_time = 0  # Track last error time
         self.error_count = 0      # Track consecutive errors
         self.update_interval = 500  # Default update interval (ms)
@@ -281,4 +282,13 @@ class InterlocksSubsystem:
             self.logger.log(message, level)
         else:
             print(f"{level.name}: {message}")
+
+    def close_com_ports(self):
+        """
+        Closes the serial port connection upon quitting the application.
+        """
+        if self.driver and hasattr(self.driver, 'ser'):
+            if self.driver.ser and self.driver.ser.is_open:
+                self.driver.ser.close()
+                self.log(f"Closed serial port {self.com_port}", LogLevel.INFO)
 

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -291,4 +291,6 @@ class InterlocksSubsystem:
             if self.driver.ser and self.driver.ser.is_open:
                 self.driver.ser.close()
                 self.log(f"Closed serial port {self.com_port}", LogLevel.INFO)
+            else:
+                self.log(f"{self.com_port} is already closed", LogLevel.INFO)       
 

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -334,3 +334,5 @@ class ProcessMonitorSubsystem:
         if self.monitor and hasattr(self.monitor, 'disconnect'):
             self.monitor.disconnect()
             self.log(f"Closed serial port {self.com_port}", LogLevel.INFO)
+        else:
+            self.log("Connection to PMON already closed", LogLevel.INFO)

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -175,6 +175,7 @@ class ProcessMonitorSubsystem:
         self.logger = logger
         self.last_error_time = 0
         self.error_count = 0
+        self.com_port = com_port
         self.update_interval = 500  # default update interval (ms)
         self.max_interval = 5000    # Maximum update interval (ms)
 
@@ -325,3 +326,11 @@ class ProcessMonitorSubsystem:
             self.logger.log(message, level)
         else:
             print(f"{level.name}: {message}")
+
+    def close_com_ports(self):
+        """
+        Closes the serial port connection upon quitting the application.
+        """
+        if self.monitor and hasattr(self.monitor, 'disconnect'):
+            self.monitor.disconnect()
+            self.log(f"Closed serial port {self.com_port}", LogLevel.INFO)

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -547,4 +547,6 @@ class VTRXSubsystem:
         if self.ser and self.ser.is_open:
             self.ser.close()
             self.log(f"Closed serial port {self.serial_port}", LogLevel.INFO)
+        else:
+            self.log(f"{self.serial_port} port already closed", LogLevel.INFO)
           

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -538,4 +538,13 @@ class VTRXSubsystem:
             self.stop_serial_thread()
             if self.ser and self.ser.is_open:
                 self.ser.close()
+
+    def close_com_ports(self):
+        """
+        Closes the serial port connection and stops the serial thread upon quitting the application.
+        """
+        self.stop_serial_thread()
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+            self.log(f"Closed serial port {self.serial_port}", LogLevel.INFO)
           


### PR DESCRIPTION
This is more of a graceful-start feature rather than graceful-exit. Earlier we had trouble re-running application as some subsystems like PMON and SIC weren't displaying any readings. This usually occurred when we tried to run the application with all the connected subsystems and had to re-start the laptop itself to re-establish connection with the subsystems. 

I just made a cleanup method in dashboard.py which calls the closed_com_ports method for every subsystem and closes all open com ports. This is reported in the log file which is accessible after quitting the application to confirm which specific ports have been closed. 
