### PR TITLE
Feature/taller machine status and allow fixed height as only set dimension

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -34,7 +34,7 @@ frames_config = [
     ("Cathode Heating", 4, 980, 450),
 
     # Row 5
-    ("Machine Status", 5, None, 50)
+    ("Machine Status", 5, None, 55)
 ]
 
 class EBEAMSystemDashboard:

--- a/dashboard.py
+++ b/dashboard.py
@@ -34,7 +34,7 @@ frames_config = [
     ("Cathode Heating", 4, 980, 450),
 
     # Row 5
-    ("Machine Status", 5, None, 55)
+    ("Machine Status", 5, None, 42)
 ]
 
 class EBEAMSystemDashboard:
@@ -118,11 +118,23 @@ class EBEAMSystemDashboard:
         global frames_config
 
         for title, row, width, height in frames_config:
+            # If both width and height are present, set them
             if width and height and title:
                 frame = tk.Frame( borderwidth=1, relief="solid", width=width, height=height)
                 frame.pack_propagate(False)
             else:
                 frame = tk.Frame(borderwidth=1, relief="solid")
+                # Check if only width or only height was given
+                dimension_set = False
+                if width and title:
+                    frame.configure(width=width)
+                    dimension_set = True
+                if height and title:
+                    frame.configure(height=height)
+                    dimension_set = True
+                # If we set either width or height, turn off propogation so dims stick
+                if dimension_set:
+                    frame.pack_propagate(False)
             self.rows[row].add(frame, stretch='always')
             if title not in ["Interlocks", "Machine Status"]:
                 self.add_title(frame, title)


### PR DESCRIPTION
The pull request slightly increases the height of the Machine Status bar at the bottom of the GUI, which was too small before and the text was running off a bit.

Additionally, it looks like the previous develop branch code did not allow you to set a fixed height for a frame while allowing no dimension on the width (so it would still stretch across the screen). This PR fixes the logic to allow setting height alone or width alone without having the other set.

![image](https://github.com/user-attachments/assets/a6712be3-669b-4996-bc25-03c71c6d8b93)
