### PR TITLE
Feature/beams off button

### DIFF
--- a/citestfiles/CathodeHeating/beams_off_test.py
+++ b/citestfiles/CathodeHeating/beams_off_test.py
@@ -65,5 +65,79 @@ class TestBeamsOff(unittest.TestCase):
         self.subsys.power_supplies[2].set_output.assert_called_once_with("0")
         self.assertFalse(self.subsys.toggle_states[2])
 
+    def test_returns_early_when_not_initialized(self):
+        # Arrange: pretend subsystem not initialized
+        self.subsys.power_supplies_initialized = False
+        # Keep mocks to detect accidental calls
+        self.subsys.power_supplies = [MagicMock(), MagicMock(), MagicMock()]
+        self.subsys.power_supply_status = [True, True, True]
+
+        # Act
+        self.turn_off_all_beams()
+
+        # Assert: no calls made
+        for ps in self.subsys.power_supplies:
+            ps.set_output.assert_not_called()
+        for btn in self.subsys.toggle_buttons:
+            btn.config.assert_not_called()
+
+    def test_skips_when_status_false_even_if_ps_present(self):
+        # Arrange: ps exists but status is False
+        self.subsys.power_supplies = [MagicMock(), MagicMock(), MagicMock()]
+        self.subsys.power_supply_status = [True, False, True]
+        self.subsys.power_supplies[0].set_output.return_value = True
+        self.subsys.power_supplies[2].set_output.return_value = True
+
+        # Act
+        self.turn_off_all_beams()
+
+        # Assert
+        self.subsys.power_supplies[1].set_output.assert_not_called()
+
+    def test_updates_button_with_correct_image_on_success(self):
+        # Arrange
+        self.subsys.power_supplies[0].set_output.return_value = True
+        self.subsys.power_supplies[2].set_output.return_value = True
+
+        # Act
+        self.turn_off_all_beams()
+
+        # Assert exact image argument used
+        self.subsys.toggle_buttons[0].config.assert_called_once_with(image=self.subsys.toggle_off_image)
+        self.subsys.toggle_buttons[2].config.assert_called_once_with(image=self.subsys.toggle_off_image)
+
+    def test_true_status_but_none_power_supply_is_safely_skipped(self):
+        # Arrange: ps None but status True for index 1
+        self.subsys.power_supplies = [MagicMock(), None, MagicMock()]
+        self.subsys.power_supply_status = [True, True, True]
+        self.subsys.power_supplies[0].set_output.return_value = True
+        self.subsys.power_supplies[2].set_output.return_value = True
+
+        # Act (should not raise)
+        self.turn_off_all_beams()
+
+        # Assert: others still called, middle skipped
+        self.subsys.power_supplies[0].set_output.assert_called_once_with("0")
+        self.subsys.power_supplies[2].set_output.assert_called_once_with("0")
+
+        # Button 1 should not be touched since ps is None
+        self.subsys.toggle_buttons[1].config.assert_not_called()
+
+    def test_second_call_is_idempotent_and_keeps_off_state(self):
+        # Arrange first call success
+        self.subsys.power_supplies[0].set_output.return_value = True
+        self.subsys.power_supplies[2].set_output.return_value = True
+
+        # Act: call twice
+        self.turn_off_all_beams()
+        self.turn_off_all_beams()
+
+        # Assert: set_output called twice for active channels
+        self.assertEqual(self.subsys.power_supplies[0].set_output.call_count, 2)
+        self.assertEqual(self.subsys.power_supplies[2].set_output.call_count, 2)
+        # State remains off
+        self.assertFalse(self.subsys.toggle_states[0])
+        self.assertFalse(self.subsys.toggle_states[2])
+
 if __name__ == '__main__':
     unittest.main()

--- a/citestfiles/CathodeHeating/beams_off_test.py
+++ b/citestfiles/CathodeHeating/beams_off_test.py
@@ -1,0 +1,69 @@
+import sys, os, unittest
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from subsystem.cathode_heating.cathode_heating import CathodeHeatingSubsystem
+from utils import LogLevel
+
+class TestBeamsOff(unittest.TestCase):
+    def setUp(self):
+        # Bypass __init__ to avoid Tk and image loading
+        self.subsys = object.__new__(CathodeHeatingSubsystem)
+        # Inject only what turn_off_all_beams uses
+        self.subsys.power_supplies_initialized = True
+        self.subsys.power_supplies = [MagicMock(), None, MagicMock()]
+        self.subsys.power_supply_status = [True, False, True]
+        self.subsys.toggle_states = [True, True, True]
+        self.subsys.toggle_off_image = object()
+        self.subsys.toggle_buttons = [MagicMock(), MagicMock(), MagicMock()]
+        # Simple logger hook
+        self.subsys.logger = MagicMock()
+        self.subsys.log = lambda msg, lvl=LogLevel.INFO: None
+
+        # Alias method under test (name in your file)
+        self.turn_off_all_beams = self.subsys.turn_off_all_beams
+
+    def test_turns_off_only_initialized_ps_and_updates_ui_on_success(self):
+        # First and third supply return True; middle is uninitialized
+        self.subsys.power_supplies[0].set_output.return_value = True
+        self.subsys.power_supplies[2].set_output.return_value = True
+
+        self.turn_off_all_beams()
+
+        self.subsys.power_supplies[0].set_output.assert_called_once_with("0")
+        self.subsys.power_supplies[2].set_output.assert_called_once_with("0")
+        self.assertFalse(self.subsys.toggle_states[0])
+        self.assertFalse(self.subsys.toggle_states[2])
+        self.subsys.toggle_buttons[0].config.assert_called_once()
+        self.subsys.toggle_buttons[2].config.assert_called_once()
+        # Uninitialized index 1 untouched
+        self.subsys.toggle_buttons[1].config.assert_not_called()
+
+    def test_does_not_update_ui_when_off_fails(self):
+        # Simulate failure on index 0, success on index 2
+        self.subsys.power_supplies[0].set_output.return_value = False
+        self.subsys.power_supplies[2].set_output.return_value = True
+
+        self.turn_off_all_beams()
+
+        # UI should not change for failed OFF
+        self.assertTrue(self.subsys.toggle_states[0])
+        self.subsys.toggle_buttons[0].config.assert_not_called()
+
+        # UI should change for successful OFF
+        self.assertFalse(self.subsys.toggle_states[2])
+        self.subsys.toggle_buttons[2].config.assert_called_once()
+
+    def test_exceptions_are_caught_and_others_continue(self):
+        self.subsys.power_supplies[0].set_output.side_effect = RuntimeError("boom")
+        self.subsys.power_supplies[2].set_output.return_value = True
+
+        # Should not raise
+        self.turn_off_all_beams()
+
+        self.subsys.power_supplies[2].set_output.assert_called_once_with("0")
+        self.assertFalse(self.subsys.toggle_states[2])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dashboard.py
+++ b/dashboard.py
@@ -150,7 +150,7 @@ class EBEAMSystemDashboard:
             text="BEAMS OFF",
             bg="red",
             fg="white",
-            font=("Helvetica", 16, "bold"),
+            font=("Helvetica",16,"bold"),
             command=lambda:self.subsystems['Cathode Heating'].turn_off_all_beams()
         )
         beams_off_button.pack(side="bottom", fill="x", padx=10, pady=8)

--- a/dashboard.py
+++ b/dashboard.py
@@ -144,6 +144,17 @@ class EBEAMSystemDashboard:
         main_frame = ttk.Frame(main_tab, padding="10")
         main_frame.pack(fill=tk.BOTH, expand=True)
 
+        # Add safety beams off button
+        beams_off_button = tk.Button(
+            main_frame,
+            text="BEAMS OFF",
+            bg="red",
+            fg="white",
+            font=("Helvetica", 16, "bold"),
+            command=self.subsystems['Cathode Heating'].turn_off_all_beams()
+        )
+        beams_off_button.pack(side="bottom", fill="x", padx=10, pady=8)
+
         # Script dropdown
         self.create_script_dropdown(main_frame)
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -151,7 +151,7 @@ class EBEAMSystemDashboard:
             bg="red",
             fg="white",
             font=("Helvetica", 16, "bold"),
-            command=self.subsystems['Cathode Heating'].turn_off_all_beams()
+            command=lambda:self.subsystems['Cathode Heating'].turn_off_all_beams()
         )
         beams_off_button.pack(side="bottom", fill="x", padx=10, pady=8)
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1247,28 +1247,34 @@ class CathodeHeatingSubsystem:
         current_image = self.toggle_on_image if self.toggle_states[index] else self.toggle_off_image
         self.toggle_buttons[index].config(image=current_image)
 
-    def turn_all_beams_off(self):
+    def turn_off_all_heaters(self):
         """
-        Turn off all cathode beams immediately.
-        Sets output to OFF for all initialized power supplies and updates GUI toggle states.
-        Redundantly sets power supply outputs to OFF regardless of their current 'toggle_states' status.
+        Turn off all cathode heaters by disabling power supply outputs.
 
         Side effects:
-            - Disables output for all cathode power supplies
-            - Updates toggle button images and states
+            - Disables output on all initialized power supplies
+            - Updates toggle button states and images
             - Logs actions and any errors
         """
-        for index in range(3):
-            try:
-                if self.power_supply_status[index]:
-                    self.power_supplies[index].set_output("0")  # Turn OFF the output
-                    self.toggle_states[index] = False
-                    self.toggle_buttons[index].config(image=self.toggle_off_image)  # Update toggle button image
-                    self.log(f"Turned off output for Cathode {['A', 'B', 'C'][index]}", LogLevel.INFO)
-                else:
-                    self.log(f"Power supply {index + 1} is not initialized. Skipping.", LogLevel.WARNING)
-            except Exception as e:
-                self.log(f"Failed to turn off output for Cathode {['A', 'B', 'C'][index]}: {str(e)}", LogLevel.ERROR)
+        if not self.power_supplies_initialized or not self.power_supplies:
+            self.log("Power supplies not properly initialized or list is empty.", LogLevel.ERROR)
+            return
+
+        for i, ps in enumerate(self.power_supplies):
+            if ps and self.power_supply_status[i]:
+                try:
+                    if ps.set_output("0"):
+                        self.log(f"Turned off heater for Cathode {['A', 'B', 'C'][i]}", LogLevel.INFO)
+                    else:
+                        self.log(f"Failed to turn off heater for Cathode {['A', 'B', 'C'][i]}", LogLevel.ERROR)
+                    
+                    # Update toggle state and button image
+                    self.toggle_states[i] = False
+                    self.toggle_buttons[i].config(image=self.toggle_off_image)
+                except Exception as e:
+                    self.log(f"Error turning off heater for Cathode {['A', 'B', 'C'][i]}: {str(e)}", LogLevel.ERROR)
+            else:
+                self.log(f"Power supply for Cathode {['A', 'B', 'C'][i]} is not initialized; cannot turn off heater.", LogLevel.WARNING)
         
     def set_target_current(self, index, entry_field):
         """

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -463,7 +463,7 @@ class CathodeHeatingSubsystem:
             self.parent,
             text="Beams OFF",
             style='BeamsOff.TButton',
-            command=self.turn_all_beams_off
+            command=self.turn_off_all_beams
         )
         self.beams_off_button.pack(side="top", fill="x", padx=10, pady=8)
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -193,6 +193,7 @@ class CathodeHeatingSubsystem:
         style.configure('OverTemp.TLabel', foreground='red', font=('Helvetica', 10, 'bold'))  # Overtemperature style
         style.configure('RampOn.TButton', background='green', foreground='black', font=('Helvetica', 8, 'bold'))
         style.configure('RampOff.TButton', background='red', foreground='black', font=('Helvetica', 8, 'bold')) # Ramp button style
+        style.configure('BeamsOff.TButton', background='red', foreground='red', font=('Helvetica', 12, 'bold'))
 
         # Load toggle images
         self.toggle_on_image = tk.PhotoImage(file=resource_path("media/toggle_on.png"))
@@ -456,6 +457,15 @@ class CathodeHeatingSubsystem:
         # Ensure the grid layout of config_tab accommodates the new buttons
         config_tab.columnconfigure(0, weight=1)
         config_tab.columnconfigure(1, weight=1)
+
+        # Beams Off safety button
+        self.beams_off_button = ttk.Button(
+            self.parent,
+            text="Beams OFF",
+            style='BeamsOff.TButton',
+            command=self.turn_all_beams_off
+        )
+        self.beams_off_button.pack(side="top", fill="x", padx=10, pady=8)
 
         self.init_time = datetime.datetime.now()
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -193,7 +193,7 @@ class CathodeHeatingSubsystem:
         style.configure('OverTemp.TLabel', foreground='red', font=('Helvetica', 10, 'bold'))  # Overtemperature style
         style.configure('RampOn.TButton', background='green', foreground='black', font=('Helvetica', 8, 'bold'))
         style.configure('RampOff.TButton', background='red', foreground='black', font=('Helvetica', 8, 'bold')) # Ramp button style
-        style.configure('BeamsOff.TButton', background='red', foreground='red', font=('Helvetica', 12, 'bold'))
+        style.configure('BeamsOff.TButton', background='red', foreground='white', font=('Helvetica', 12, 'bold'))
 
         # Load toggle images
         self.toggle_on_image = tk.PhotoImage(file=resource_path("media/toggle_on.png"))

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -193,7 +193,6 @@ class CathodeHeatingSubsystem:
         style.configure('OverTemp.TLabel', foreground='red', font=('Helvetica', 10, 'bold'))  # Overtemperature style
         style.configure('RampOn.TButton', background='green', foreground='black', font=('Helvetica', 8, 'bold'))
         style.configure('RampOff.TButton', background='red', foreground='black', font=('Helvetica', 8, 'bold')) # Ramp button style
-        style.configure('BeamsOff.TButton', background='red', foreground='white', font=('Helvetica', 12, 'bold'))
 
         # Load toggle images
         self.toggle_on_image = tk.PhotoImage(file=resource_path("media/toggle_on.png"))

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1241,13 +1241,24 @@ class CathodeHeatingSubsystem:
         """
         Turn off all cathode beams immediately.
         Sets output to OFF for all initialized power supplies and updates GUI toggle states.
+        Redundantly sets power supply outputs to OFF regardless of their current 'toggle_states' status.
 
         Side effects:
             - Disables output for all cathode power supplies
             - Updates toggle button images and states
             - Logs actions and any errors
         """
-        pass
+        for index in range(3):
+            try:
+                if self.power_supply_status[index]:
+                    self.power_supplies[index].set_output("0")  # Turn OFF the output
+                    self.toggle_states[index] = False
+                    self.toggle_buttons[index].config(image=self.toggle_off_image)  # Update toggle button image
+                    self.log(f"Turned off output for Cathode {['A', 'B', 'C'][index]}", LogLevel.INFO)
+                else:
+                    self.log(f"Power supply {index + 1} is not initialized. Skipping.", LogLevel.WARNING)
+            except Exception as e:
+                self.log(f"Failed to turn off output for Cathode {['A', 'B', 'C'][index]}: {str(e)}", LogLevel.ERROR)
         
     def set_target_current(self, index, entry_field):
         """

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1263,7 +1263,7 @@ class CathodeHeatingSubsystem:
         for i, ps in enumerate(self.power_supplies):
             if ps and self.power_supply_status[i]:
                 try:
-                    if ps.set_output("0"):
+                    if ps.set_output("0"): # Turn off beam
                         self.log(f"Turned off heater for Cathode {['A', 'B', 'C'][i]}", LogLevel.INFO)
                     else:
                         self.log(f"Failed to turn off heater for Cathode {['A', 'B', 'C'][i]}", LogLevel.ERROR)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1236,6 +1236,18 @@ class CathodeHeatingSubsystem:
         self.toggle_states[index] = new_state
         current_image = self.toggle_on_image if self.toggle_states[index] else self.toggle_off_image
         self.toggle_buttons[index].config(image=current_image)
+
+    def turn_all_beams_off(self):
+        """
+        Turn off all cathode beams immediately.
+        Sets output OFF for all initialized power supplies and updates GUI toggle states.
+
+        Side effects:
+            - Disables output for all cathode power supplies
+            - Updates toggle button images and states
+            - Logs actions and any errors
+        """
+        pass
         
     def set_target_current(self, index, entry_field):
         """

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1240,7 +1240,7 @@ class CathodeHeatingSubsystem:
     def turn_all_beams_off(self):
         """
         Turn off all cathode beams immediately.
-        Sets output OFF for all initialized power supplies and updates GUI toggle states.
+        Sets output to OFF for all initialized power supplies and updates GUI toggle states.
 
         Side effects:
             - Disables output for all cathode power supplies

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -458,15 +458,6 @@ class CathodeHeatingSubsystem:
         config_tab.columnconfigure(0, weight=1)
         config_tab.columnconfigure(1, weight=1)
 
-        # Beams Off safety button
-        self.beams_off_button = ttk.Button(
-            self.parent,
-            text="Beams OFF",
-            style='BeamsOff.TButton',
-            command=self.turn_off_all_beams
-        )
-        self.beams_off_button.pack(side="top", fill="x", padx=10, pady=8)
-
         self.init_time = datetime.datetime.now()
 
     def update_com_ports(self, new_com_ports):


### PR DESCRIPTION
This PR adds a "Beams Off" button to the "Main Control" panel of the dashboard. This button acts as a safety measure to quickly disable CCS heating for all three cathodes by turning off their power supply outputs. It only acts on power supplies that are initialized. Unit tests were developed for this button/logic and all pass. Button logic was tested using the Arduino emulator and the results were screen recorded. You can view the video with the gdrive link here: https://drive.google.com/file/d/1jFwtci_lECTe4VVWzayJQH5gnVnBMwH0/view?usp=sharing
